### PR TITLE
feat(study-groups): handle PostgreSQL 23505 unique constraint error

### DIFF
--- a/backend/services/study-groups/src/infrastructure/database/PostgresStudyRequestRepository.ts
+++ b/backend/services/study-groups/src/infrastructure/database/PostgresStudyRequestRepository.ts
@@ -240,6 +240,9 @@ export class PostgresStudyRequestRepository implements IStudyRequestRepository {
       if (error instanceof Error && error.message.includes("validate_request_subject")) {
         throw new Error("Solo puedes crear solicitudes de materias que estés cursando actualmente.");
       }
+      if (error && typeof error === "object" && "code" in error && error.code === "23505") {
+        throw new Error("Has alcanzado el límite de grupos activos que puedes crear.");
+      }
       throw error;
     }
   }


### PR DESCRIPTION
- Mapea error code 23505 a mensaje legible en español
- Usuario recibe: 'Has alcanzado el límite de grupos activos que puedes crear'
- No retorna 500 genérico, sino BusinessError tipado
- Integrado en create() method del repositorio